### PR TITLE
Add root to conf.paths to fix less parse error when absolute paths imported

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var less = require('less');
 var root = fis.project.getProjectPath();
 
 module.exports = function(content, file, conf){
-    conf.paths = [ file.dirname, root ];
+    conf.paths = [ file.dirname, root, ''];
     conf.syncImport = true;
     var parser = new(less.Parser)(conf);
     parser.parse(content, function (err, tree) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name" : "fis-parser-less",
     "description" : "A parser for fis to compile less file.",
-    "version" : "0.1.0",
+    "version" : "0.1.1",
     "author" : "FIS Team <fis@baidu.com>",
     "homepage" : "https://github.com/fouber/fis-parser-less",
     "keywords": [ "fis", "less" ],


### PR DESCRIPTION
当在`less`文件中`import`一个以绝对路径表示的文件时，`less`报错：

```
[ERROR] parser.less: '/Users/lee/dev/work/sglobal/_build/fis2/mixin.less' wasn't found [/Users/lee/dev/work/sglobal/widget/dialog/dialog.less:1:0]
```

在`paths`中增加了根目录以支持`import`绝对路径。
